### PR TITLE
Update Elite Shader to have painterly lighting

### DIFF
--- a/Assets/Shaders/Elites/BasicElite.shadergraph
+++ b/Assets/Shaders/Elites/BasicElite.shadergraph
@@ -4,6 +4,9 @@
     "m_ObjectId": "ad2a3a7945704a31a24a6cf4fdc087c5",
     "m_Properties": [
         {
+            "m_Id": "5c952bddea134e47aef18992c2bf4847"
+        },
+        {
             "m_Id": "d0327d29968540f39f4ce502ea32fa29"
         },
         {
@@ -16,9 +19,6 @@
             "m_Id": "5247f3bc5c8f4f3c9e226f18f686db0d"
         },
         {
-            "m_Id": "826e9a9595f145ae8f8dbf4644429123"
-        },
-        {
             "m_Id": "1b5bb67bb55a4bbda282f79c276dbb56"
         },
         {
@@ -29,6 +29,9 @@
         },
         {
             "m_Id": "56bfe73769ee4a23b025b540fb726b35"
+        },
+        {
+            "m_Id": "bf97d9783173481598953b288718a59a"
         }
     ],
     "m_Keywords": [
@@ -46,6 +49,9 @@
         },
         {
             "m_Id": "00e164872bc042019fef3bcbd950adfb"
+        },
+        {
+            "m_Id": "65f45085f4364b90897f3b20c102fb28"
         }
     ],
     "m_Nodes": [
@@ -68,40 +74,13 @@
             "m_Id": "cc4a21109dd14114afacb1dfed0dc8e7"
         },
         {
-            "m_Id": "186755f1ae094704a321b8545877fd6b"
-        },
-        {
             "m_Id": "c7fd784a897a4fbcaa7a5480c0b0b6ad"
-        },
-        {
-            "m_Id": "b82b033dbd5d4e3e963dbefd2a022528"
-        },
-        {
-            "m_Id": "34fa30f0faa547cea393f34f96ff7665"
-        },
-        {
-            "m_Id": "9ec1f14e37cb42ff9dec92d21b71f07f"
-        },
-        {
-            "m_Id": "b74dcc58a76448b69c275326e87f4ec2"
-        },
-        {
-            "m_Id": "34fb4abfddf846289e6f47299ae207b4"
-        },
-        {
-            "m_Id": "6f838dbaabde46d7a1e227838d61384b"
         },
         {
             "m_Id": "d1b856950eb241d7b1c5db10e264bc99"
         },
         {
             "m_Id": "1d3df2a47fe94542b7df12c046de500a"
-        },
-        {
-            "m_Id": "8a353c6ffe9344438d756d6d5d6f7306"
-        },
-        {
-            "m_Id": "36207540dd494fb28f7c321b41575c35"
         },
         {
             "m_Id": "abe7fd38155442778514408a281d905e"
@@ -117,12 +96,6 @@
         },
         {
             "m_Id": "72f50edae85f4ecb8505276277d855f3"
-        },
-        {
-            "m_Id": "6cc54b292e184f26b1851ad2868d17ba"
-        },
-        {
-            "m_Id": "6fe87c47c8f84437ab82916954fc6d9f"
         },
         {
             "m_Id": "d7ee1778da364c26b8266e9a3a02d57c"
@@ -155,12 +128,6 @@
             "m_Id": "f3098f9a23944b74b51d644052d740d4"
         },
         {
-            "m_Id": "ded39eb2ba814bdcae1e8c2db652b67a"
-        },
-        {
-            "m_Id": "9b724728ee0a419792d875c4fc2b433a"
-        },
-        {
             "m_Id": "801e4aae3f9748cdaeee33a62387121f"
         },
         {
@@ -174,6 +141,24 @@
         },
         {
             "m_Id": "fcb474a8f6434a30ae5582e2584a14c8"
+        },
+        {
+            "m_Id": "2973521d83b94601b65a808b8e32de85"
+        },
+        {
+            "m_Id": "6461fb6a246e4ebd8bb811ffc6bfcccb"
+        },
+        {
+            "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
+        },
+        {
+            "m_Id": "576f53a643174141b4cda173b54bb001"
+        },
+        {
+            "m_Id": "db93a193d2364837bd8ce004ed486f9d"
+        },
+        {
+            "m_Id": "d49f265460374f5dbde10f63ddd67271"
         }
     ],
     "m_GroupDatas": [
@@ -182,9 +167,6 @@
         },
         {
             "m_Id": "2cb95ef2ae034f419ace077f95de0bd1"
-        },
-        {
-            "m_Id": "161e8762977a421496347a75ca55bbf6"
         },
         {
             "m_Id": "ac5bd7ac8c3e453d8bf386077e640532"
@@ -205,20 +187,6 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "4f3bda1ee06248b8ac7de57256c7dae6"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "186755f1ae094704a321b8545877fd6b"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "6fe87c47c8f84437ab82916954fc6d9f"
                 },
                 "m_SlotId": 1
             }
@@ -260,7 +228,21 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "36207540dd494fb28f7c321b41575c35"
+                    "m_Id": "8f8d28b2968f40b8b2e4c7e67f4927d0"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "2973521d83b94601b65a808b8e32de85"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6461fb6a246e4ebd8bb811ffc6bfcccb"
                 },
                 "m_SlotId": 0
             }
@@ -268,15 +250,15 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "1d3df2a47fe94542b7df12c046de500a"
+                    "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "ded39eb2ba814bdcae1e8c2db652b67a"
+                    "m_Id": "3289e43b349e4ba9aa9ec65cf6229215"
                 },
-                "m_SlotId": 1
+                "m_SlotId": 0
             }
         },
         {
@@ -288,23 +270,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "71ec58129f394ded8825cd3d71892c0e"
+                    "m_Id": "2973521d83b94601b65a808b8e32de85"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "36207540dd494fb28f7c321b41575c35"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "8f8d28b2968f40b8b2e4c7e67f4927d0"
-                },
-                "m_SlotId": 1
             }
         },
         {
@@ -324,6 +292,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "576f53a643174141b4cda173b54bb001"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
+                },
+                "m_SlotId": 1841062939
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "58ddc03e622843ca8d8927280761a6af"
                 },
                 "m_SlotId": 0
@@ -338,6 +320,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "6461fb6a246e4ebd8bb811ffc6bfcccb"
+                },
+                "m_SlotId": 1
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "71ec58129f394ded8825cd3d71892c0e"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "65d31bcd75084a66b18a57f2747414fa"
                 },
                 "m_SlotId": 0
@@ -345,48 +341,6 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "8607faf3572649b9b2de138a61e37603"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "6cc54b292e184f26b1851ad2868d17ba"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "6fe87c47c8f84437ab82916954fc6d9f"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "6f838dbaabde46d7a1e227838d61384b"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "b74dcc58a76448b69c275326e87f4ec2"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "6fe87c47c8f84437ab82916954fc6d9f"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "3289e43b349e4ba9aa9ec65cf6229215"
                 },
                 "m_SlotId": 0
             }
@@ -450,20 +404,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "8a353c6ffe9344438d756d6d5d6f7306"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "6f838dbaabde46d7a1e227838d61384b"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "8f392067f4c84936b08a28acb91f9047"
                 },
                 "m_SlotId": 1
@@ -492,6 +432,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "8f8d28b2968f40b8b2e4c7e67f4927d0"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
+                },
+                "m_SlotId": 164958765
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "972253a706da4f3a85ea8b8461bdd927"
                 },
                 "m_SlotId": 0
@@ -501,20 +455,6 @@
                     "m_Id": "8607faf3572649b9b2de138a61e37603"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "9b724728ee0a419792d875c4fc2b433a"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ded39eb2ba814bdcae1e8c2db652b67a"
-                },
-                "m_SlotId": 2
             }
         },
         {
@@ -554,9 +494,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "186755f1ae094704a321b8545877fd6b"
+                    "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
                 },
-                "m_SlotId": 1
+                "m_SlotId": -894933319
             }
         },
         {
@@ -590,6 +530,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "d49f265460374f5dbde10f63ddd67271"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
+                },
+                "m_SlotId": 186768313
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "d7ee1778da364c26b8266e9a3a02d57c"
                 },
                 "m_SlotId": 1
@@ -599,6 +553,20 @@
                     "m_Id": "4f3bda1ee06248b8ac7de57256c7dae6"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "db93a193d2364837bd8ce004ed486f9d"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2d6d16e9d31649079d6c7947c2ab4fe1"
+                },
+                "m_SlotId": -2092072667
             }
         },
         {
@@ -646,29 +614,15 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "ded39eb2ba814bdcae1e8c2db652b67a"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "34fa30f0faa547cea393f34f96ff7665"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "df1174a794a24184b63f4372db0cd4e5"
                 },
                 "m_SlotId": 2
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "9ec1f14e37cb42ff9dec92d21b71f07f"
+                    "m_Id": "2973521d83b94601b65a808b8e32de85"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             }
         },
         {
@@ -716,8 +670,8 @@
     ],
     "m_VertexContext": {
         "m_Position": {
-            "x": 0.0,
-            "y": 0.0
+            "x": 133.0000457763672,
+            "y": -99.99998474121094
         },
         "m_Blocks": [
             {
@@ -733,27 +687,12 @@
     },
     "m_FragmentContext": {
         "m_Position": {
-            "x": 0.0,
-            "y": 200.0
+            "x": 133.0000457763672,
+            "y": 100.00000762939453
         },
         "m_Blocks": [
             {
                 "m_Id": "71ec58129f394ded8825cd3d71892c0e"
-            },
-            {
-                "m_Id": "b82b033dbd5d4e3e963dbefd2a022528"
-            },
-            {
-                "m_Id": "9ec1f14e37cb42ff9dec92d21b71f07f"
-            },
-            {
-                "m_Id": "b74dcc58a76448b69c275326e87f4ec2"
-            },
-            {
-                "m_Id": "34fb4abfddf846289e6f47299ae207b4"
-            },
-            {
-                "m_Id": "34fa30f0faa547cea393f34f96ff7665"
             }
         ]
     },
@@ -808,19 +747,13 @@
     "m_Name": "Color",
     "m_ChildObjectList": [
         {
+            "m_Id": "bf97d9783173481598953b288718a59a"
+        },
+        {
             "m_Id": "e94fc321aef84c0dac77be978ed9e848"
         },
         {
-            "m_Id": "c9bf18b38694443ba26aec0759c65f33"
-        },
-        {
-            "m_Id": "56bfe73769ee4a23b025b540fb726b35"
-        },
-        {
-            "m_Id": "21846d02d4374904ae8b551e51791cb6"
-        },
-        {
-            "m_Id": "12776e2febe744778d0275876f02a8e5"
+            "m_Id": "5c952bddea134e47aef18992c2bf4847"
         },
         {
             "m_Id": "d0327d29968540f39f4ce502ea32fa29"
@@ -830,16 +763,26 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "036df685c9264ee4b65c4a7798bb72f1",
-    "m_Id": 5,
-    "m_DisplayName": "G",
-    "m_SlotType": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "0394293911eb462e804eee8df812f20a",
+    "m_Id": -2092072667,
+    "m_DisplayName": "SpecularColor",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "G",
+    "m_ShaderOutputName": "_SpecularColor",
     "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
     "m_Labels": []
 }
 
@@ -855,10 +798,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -945.9999389648438,
-            "y": 347.0,
-            "width": 163.99993896484376,
-            "height": 142.0
+            "x": -944.0000610351563,
+            "y": 324.0000305175781,
+            "width": 164.0,
+            "height": 142.00003051757813
         }
     },
     "m_Slots": [
@@ -898,68 +841,6 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "0b6d936956c5477f97311299f0a77c44",
-    "m_Id": 0,
-    "m_DisplayName": "RGBA",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "RGBA",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "0e7913707b264f65bffbd639243aea51",
-    "m_Id": 0,
-    "m_DisplayName": "Ambient Occlusion",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Occlusion",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 1.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
-    "m_ObjectId": "0f568a7cbeed443180c8ddc1c5e99223",
-    "m_Id": 2,
-    "m_DisplayName": "UV",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "UV",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_Labels": [],
-    "m_Channel": 0
 }
 
 {
@@ -1007,54 +888,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
-    "m_ObjectId": "1382da29f9234c529fbb2bf6ee1711f2",
-    "m_Id": 1,
-    "m_DisplayName": "B",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "e00": 2.0,
-        "e01": 2.0,
-        "e02": 2.0,
-        "e03": 2.0,
-        "e10": 2.0,
-        "e11": 2.0,
-        "e12": 2.0,
-        "e13": 2.0,
-        "e20": 2.0,
-        "e21": 2.0,
-        "e22": 2.0,
-        "e23": 2.0,
-        "e30": 2.0,
-        "e31": 2.0,
-        "e32": 2.0,
-        "e33": 2.0
-    },
-    "m_DefaultValue": {
-        "e00": 1.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 1.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 1.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "14d4ddd6d0004128a0ba5d81d42d1477",
     "m_Id": 2,
@@ -1085,97 +918,17 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "1558cd30c99d4127be92b324cac00d6f",
-    "m_Id": 2,
-    "m_DisplayName": "Off",
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "17ed9ee9e41547fe875b44527b3ce782",
+    "m_Id": -38357785,
+    "m_DisplayName": "Scale",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Off",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.GroupData",
-    "m_ObjectId": "161e8762977a421496347a75ca55bbf6",
-    "m_Title": "AO",
-    "m_Position": {
-        "x": -654.0,
-        "y": 599.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
-    "m_ObjectId": "186755f1ae094704a321b8545877fd6b",
-    "m_Group": {
-        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
-    },
-    "m_Name": "Sample Texture 2D",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -728.9998779296875,
-            "y": -88.99996185302735,
-            "width": 182.9998779296875,
-            "height": 251.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "eb782c5f81b449d29783549f95172d7a"
-        },
-        {
-            "m_Id": "9c6009f4fd4d446396a90b2f244a33ad"
-        },
-        {
-            "m_Id": "45bfb2609d9d450f802bdc9ab85b60af"
-        },
-        {
-            "m_Id": "60411efe9e124ebf8da946422f6c6edc"
-        },
-        {
-            "m_Id": "6caecc5e284748f28e680151d2a48929"
-        },
-        {
-            "m_Id": "484db0e523b54f83a4dea4ced768f46b"
-        },
-        {
-            "m_Id": "0f568a7cbeed443180c8ddc1c5e99223"
-        },
-        {
-            "m_Id": "5918e95a9b09443da9f7a4d7b7e4cbe6"
-        }
-    ],
-    "synonyms": [
-        "tex2d"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_TextureType": 0,
-    "m_NormalMapSpace": 0,
-    "m_EnableGlobalMipBias": true,
-    "m_MipSamplingMode": 0
+    "m_ShaderOutputName": "_Scale",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -1190,10 +943,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -638.9999389648438,
-            "y": 324.0,
-            "width": 147.99996948242188,
-            "height": 118.00003051757813
+            "x": -637.0000610351563,
+            "y": 301.0000305175781,
+            "width": 148.0,
+            "height": 118.0
         }
     },
     "m_Slots": [
@@ -1308,10 +1061,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1668.0001220703125,
-            "y": 807.0000610351563,
+            "x": -1315.0,
+            "y": -221.0,
             "width": 183.0,
-            "height": 251.00006103515626
+            "height": 251.0
         }
     },
     "m_Slots": [
@@ -1351,7 +1104,7 @@
         "m_SerializableColors": []
     },
     "m_TextureType": 1,
-    "m_NormalMapSpace": 0,
+    "m_NormalMapSpace": 1,
     "m_EnableGlobalMipBias": true,
     "m_MipSamplingMode": 0
 }
@@ -1410,30 +1163,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "259cf6afeae44aab9bfcaec6f1e206c7",
-    "m_Id": 1,
-    "m_DisplayName": "On",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "On",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "25a64b843333420da01212159f7f2ff8",
     "m_Id": 3,
@@ -1445,6 +1174,49 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "2973521d83b94601b65a808b8e32de85",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Add",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -247.00010681152345,
+            "y": 101.00003051757813,
+            "width": 130.0,
+            "height": 117.99996948242188
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "8a2e88af140e4b59b87ea06926e001c2"
+        },
+        {
+            "m_Id": "a2e9f586e9634d97bc944529a465dd9b"
+        },
+        {
+            "m_Id": "6ce133e427ac45b1a82bdcf7602b6433"
+        }
+    ],
+    "synonyms": [
+        "addition",
+        "sum",
+        "plus"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -1490,9 +1262,99 @@
     "m_ObjectId": "2cb95ef2ae034f419ace077f95de0bd1",
     "m_Title": "Normals",
     "m_Position": {
-        "x": -1837.0001220703125,
-        "y": 592.9999389648438
+        "x": -1484.0,
+        "y": -279.9999694824219
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
+    "m_ObjectId": "2d6d16e9d31649079d6c7947c2ab4fe1",
+    "m_Group": {
+        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
+    },
+    "m_Name": "PainterlyLighting",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -716.0,
+            "y": -256.0000305175781,
+            "width": 226.99993896484376,
+            "height": 310.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "67cdb6593997470b925c1c3767c6f5b9"
+        },
+        {
+            "m_Id": "bf2ef47f1c64413e9ec45bd5ba25c84f"
+        },
+        {
+            "m_Id": "b47c87c2da3344eda6f8e3ce0cd30d59"
+        },
+        {
+            "m_Id": "17ed9ee9e41547fe875b44527b3ce782"
+        },
+        {
+            "m_Id": "b82abf752eb04b20b40673411e2ae74d"
+        },
+        {
+            "m_Id": "f9daa7f963ef414abd7fd35dfc0e522f"
+        },
+        {
+            "m_Id": "7bb4265308c24e6c9ec15318a064a1bd"
+        },
+        {
+            "m_Id": "0394293911eb462e804eee8df812f20a"
+        },
+        {
+            "m_Id": "d12dd8a84df14bed98a950fdfa3dc761"
+        },
+        {
+            "m_Id": "abf799f907dd423ea40d4cfe10a3f978"
+        },
+        {
+            "m_Id": "67b79b823f4b458c96d5afe28ff5c9a7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedSubGraph": "{\n    \"subGraph\": {\n        \"fileID\": -5475051401550479605,\n        \"guid\": \"6222586232a4d7f45892979cf292e625\",\n        \"type\": 3\n    }\n}",
+    "m_PropertyGuids": [
+        "7a35add2-1c83-4b20-b175-34e459a2891f",
+        "08da6567-97c9-4517-8c77-52590f974a1d",
+        "63a67190-411c-4d24-a7ea-99038530550c",
+        "eb5a32b5-46f0-4a77-92d9-00c730199b9b",
+        "5404568c-b7ea-4ca3-8e7b-934711ed9114",
+        "6d509d42-80c6-432f-be65-528a0c8d0512",
+        "55df1384-4a06-46bf-9d44-917087b03bcb",
+        "f431355b-ca01-495c-bee4-a155c19a816b",
+        "d43ad454-29ca-4afb-b96d-849d3cf4f96e",
+        "dedb0f9c-8afc-4e4f-9fe2-eaea46bc5f71"
+    ],
+    "m_PropertyIds": [
+        -894933319,
+        164958765,
+        558820014,
+        -38357785,
+        1269135353,
+        -1238829770,
+        -1463112296,
+        -2092072667,
+        1841062939,
+        186768313
+    ],
+    "m_Dropdowns": [],
+    "m_DropdownSelectedEntries": []
 }
 
 {
@@ -1562,10 +1424,10 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.GroupData",
     "m_ObjectId": "30728c35ddbe42ec95150e3ffcac58bd",
-    "m_Title": "Albedo",
+    "m_Title": "Base Controls",
     "m_Position": {
-        "x": -898.0,
-        "y": -181.99990844726563
+        "x": -904.0,
+        "y": -315.0000305175781
     }
 }
 
@@ -1581,10 +1443,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -367.9998779296875,
-            "y": -120.99992370605469,
-            "width": 129.9999237060547,
-            "height": 117.99995422363281
+            "x": -485.0000915527344,
+            "y": -256.0000305175781,
+            "width": 130.00003051757813,
+            "height": 118.0
         }
     },
     "m_Slots": [
@@ -1625,123 +1487,6 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "34fa30f0faa547cea393f34f96ff7665",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.NormalTS",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 3.999997138977051,
-            "y": 424.0,
-            "width": 200.0,
-            "height": 41.000030517578128
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "8ef8e770565b4b02aba61695a6b19cdd"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "34fb4abfddf846289e6f47299ae207b4",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Metallic",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "f36af3c572574959a133a2cec54c406a"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
-}
-
-{
-    "m_SGVersion": 2,
-    "m_Type": "UnityEditor.ShaderGraph.TransformNode",
-    "m_ObjectId": "36207540dd494fb28f7c321b41575c35",
-    "m_Group": {
-        "m_Id": "2cb95ef2ae034f419ace077f95de0bd1"
-    },
-    "m_Name": "Transform",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -1485.0001220703125,
-            "y": 807.0000610351563,
-            "width": 213.0,
-            "height": 157.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "391c90dd8d154ab99a805fa655b0cd80"
-        },
-        {
-            "m_Id": "ebed97b71d18469a8ce46fca4fed7713"
-        }
-    ],
-    "synonyms": [
-        "world",
-        "tangent",
-        "object",
-        "view",
-        "screen",
-        "convert"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Conversion": {
-        "from": 3,
-        "to": 2
-    },
-    "m_ConversionType": 1,
-    "m_Normalize": true
 }
 
 {
@@ -1804,29 +1549,6 @@
     "m_StageCapability": 2,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "391c90dd8d154ab99a805fa655b0cd80",
-    "m_Id": 0,
-    "m_DisplayName": "In",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "In",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
     "m_Labels": []
 }
 
@@ -2019,39 +1741,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "45bfb2609d9d450f802bdc9ab85b60af",
-    "m_Id": 5,
-    "m_DisplayName": "G",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "G",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "484db0e523b54f83a4dea4ced768f46b",
-    "m_Id": 1,
-    "m_DisplayName": "Texture",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Texture",
-    "m_StageCapability": 3,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "486f099dfb3b43e89b3f4b9264159991",
     "m_Id": 5,
     "m_DisplayName": "G",
@@ -2154,10 +1843,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -780.0,
-            "y": 324.0000305175781,
+            "x": -778.0000610351563,
+            "y": 301.0000305175781,
             "width": 126.00006103515625,
-            "height": 117.99996948242188
+            "height": 118.0
         }
     },
     "m_Slots": [
@@ -2183,6 +1872,12 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 2,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalUnlitSubTarget",
+    "m_ObjectId": "51c1eb23a4004cceb631d2c85a28df50"
 }
 
 {
@@ -2282,6 +1977,42 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "576f53a643174141b4cda173b54bb001",
+    "m_Group": {
+        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -858.0,
+            "y": -12.0,
+            "width": 142.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "da82c36db55b4fb8872ea26a1d8fdde8"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "e94fc321aef84c0dac77be978ed9e848"
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "58491784c1f5450b90698eaed01ff571",
     "m_Id": 2,
@@ -2351,19 +2082,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
-    "m_ObjectId": "5918e95a9b09443da9f7a4d7b7e4cbe6",
-    "m_Id": 3,
-    "m_DisplayName": "Sampler",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Sampler",
-    "m_StageCapability": 3,
-    "m_BareResource": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "5b1bd4a2e96f4dae814f33d33850e819",
     "m_Id": 0,
@@ -2391,18 +2109,33 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "5c7658c077f4454abc7bbc985610050f",
-    "m_Id": 6,
-    "m_DisplayName": "B",
-    "m_SlotType": 1,
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "5c952bddea134e47aef18992c2bf4847",
+    "m_Guid": {
+        "m_GuidSerialized": "df61a80d-46c5-45b7-8aeb-d55a4bd79494"
+    },
+    "m_Name": "ShadowColor",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "ShadowColor",
+    "m_DefaultReferenceName": "_ShadowColor",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
+    "m_Value": {
+        "r": 0.6000000238418579,
+        "g": 0.6000000238418579,
+        "b": 0.6000000238418579,
+        "a": 0.0
+    },
+    "isMainColor": false,
+    "m_ColorMode": 0
 }
 
 {
@@ -2431,17 +2164,64 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "60411efe9e124ebf8da946422f6c6edc",
-    "m_Id": 6,
-    "m_DisplayName": "B",
-    "m_SlotType": 1,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "5effb898d3d847fc997f7a615f09a16c",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "B",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SaturateNode",
+    "m_ObjectId": "6461fb6a246e4ebd8bb811ffc6bfcccb",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Saturate",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -117.0000991821289,
+            "y": 100.00000762939453,
+            "width": 132.0000457763672,
+            "height": 93.99999237060547
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5effb898d3d847fc997f7a615f09a16c"
+        },
+        {
+            "m_Id": "e1a3d6005e4549898304d75cc2efbdb9"
+        }
+    ],
+    "synonyms": [
+        "clamp"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -2491,6 +2271,68 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "65f45085f4364b90897f3b20c102fb28",
+    "m_Name": "Fresnel",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "c9bf18b38694443ba26aec0759c65f33"
+        },
+        {
+            "m_Id": "56bfe73769ee4a23b025b540fb726b35"
+        },
+        {
+            "m_Id": "21846d02d4374904ae8b551e51791cb6"
+        },
+        {
+            "m_Id": "12776e2febe744778d0275876f02a8e5"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "67b79b823f4b458c96d5afe28ff5c9a7",
+    "m_Id": 1,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "67cdb6593997470b925c1c3767c6f5b9",
+    "m_Id": -894933319,
+    "m_DisplayName": "BaseMap",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_BaseMap",
+    "m_StageCapability": 2,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "68a3e33ee86f4396b9c0c728315d0a71",
     "m_Id": 1818628424,
@@ -2530,52 +2372,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "6caecc5e284748f28e680151d2a48929",
-    "m_Id": 7,
-    "m_DisplayName": "A",
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6ce133e427ac45b1a82bdcf7602b6433",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
     "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "6cc54b292e184f26b1851ad2868d17ba",
-    "m_Group": {
-        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -676.9999389648438,
-            "y": -122.9999008178711,
-            "width": 130.99993896484376,
-            "height": 33.99993896484375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "bbc92a58ac1344e4b63eb311b5dff878"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "e94fc321aef84c0dac77be978ed9e848"
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -2605,6 +2420,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "6d09f8f669af4fc0b47b3cff48b810c7",
+    "m_Id": 0,
+    "m_DisplayName": "ShadowColor",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "6e4dc1c6647448f0b818edb67f349cbd",
     "m_Id": 0,
@@ -2629,66 +2469,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
-    "m_ObjectId": "6f838dbaabde46d7a1e227838d61384b",
-    "m_Group": {
-        "m_Id": "161e8762977a421496347a75ca55bbf6"
-    },
-    "m_Name": "Sample Texture 2D",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -529.0001831054688,
-            "y": 658.0,
-            "width": 183.00009155273438,
-            "height": 251.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "0b6d936956c5477f97311299f0a77c44"
-        },
-        {
-            "m_Id": "77d8790ae47a474886ba184ae5d05b5d"
-        },
-        {
-            "m_Id": "036df685c9264ee4b65c4a7798bb72f1"
-        },
-        {
-            "m_Id": "5c7658c077f4454abc7bbc985610050f"
-        },
-        {
-            "m_Id": "f484082f4a434d67ae8cd2513c8f91a6"
-        },
-        {
-            "m_Id": "fbb5378cbc234d17b565ac1770a5274b"
-        },
-        {
-            "m_Id": "7361df2c0c744667a9a7af1e0973e164"
-        },
-        {
-            "m_Id": "d88a06f4f74649a7b90b16ff61387879"
-        }
-    ],
-    "synonyms": [
-        "tex2d"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_TextureType": 0,
-    "m_NormalMapSpace": 0,
-    "m_EnableGlobalMipBias": true,
-    "m_MipSamplingMode": 0
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "6fe217d1ef4f4cad80f6cc489563a969",
     "m_Id": 0,
@@ -2708,49 +2488,6 @@
         "z": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
-    "m_ObjectId": "6fe87c47c8f84437ab82916954fc6d9f",
-    "m_Group": {
-        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
-    },
-    "m_Name": "Multiply",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -518.0,
-            "y": -120.99992370605469,
-            "width": 130.00015258789063,
-            "height": 117.99995422363281
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "a78f5e98db5c4954a0ec3205ccbc5c5f"
-        },
-        {
-            "m_Id": "1382da29f9234c529fbb2bf6ee1711f2"
-        },
-        {
-            "m_Id": "8aae8bfaa7ce49a49a464b4e04e3a899"
-        }
-    ],
-    "synonyms": [
-        "multiplication",
-        "times",
-        "x"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
 }
 
 {
@@ -2823,10 +2560,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -635.0000610351563,
-            "y": 290.00006103515627,
-            "width": 144.00009155273438,
-            "height": 33.99993896484375
+            "x": -633.0,
+            "y": 267.0,
+            "width": 143.99993896484376,
+            "height": 34.000030517578128
         }
     },
     "m_Slots": [
@@ -2845,28 +2582,6 @@
     "m_Property": {
         "m_Id": "d0327d29968540f39f4ce502ea32fa29"
     }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
-    "m_ObjectId": "7361df2c0c744667a9a7af1e0973e164",
-    "m_Id": 2,
-    "m_DisplayName": "UV",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "UV",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0
-    },
-    "m_Labels": [],
-    "m_Channel": 0
 }
 
 {
@@ -2918,21 +2633,6 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "77d8790ae47a474886ba184ae5d05b5d",
-    "m_Id": 4,
-    "m_DisplayName": "R",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "R",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.PositionNode",
     "m_ObjectId": "7a047abff5364f0fb39203d5dccf154c",
@@ -2971,15 +2671,27 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "7bb4265308c24e6c9ec15318a064a1bd",
+    "m_Id": -1463112296,
+    "m_DisplayName": "MinShadowStrength",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_MinShadowStrength",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.CategoryData",
     "m_ObjectId": "7e9ae02fd262487e857edaaaf8a37119",
     "m_Name": "Textures",
     "m_ChildObjectList": [
         {
             "m_Id": "5247f3bc5c8f4f3c9e226f18f686db0d"
-        },
-        {
-            "m_Id": "826e9a9595f145ae8f8dbf4644429123"
         },
         {
             "m_Id": "a64d5d6c997547d79dcd7da03c4b9232"
@@ -3002,10 +2714,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -887.0,
-            "y": 489.0,
+            "x": -885.0000610351563,
+            "y": 466.00006103515627,
             "width": 105.0,
-            "height": 34.0
+            "height": 33.999969482421878
         }
     },
     "m_Slots": [
@@ -3052,32 +2764,27 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
-    "m_ObjectId": "826e9a9595f145ae8f8dbf4644429123",
-    "m_Guid": {
-        "m_GuidSerialized": "eff98f18-30fe-415a-ae06-159bc8bd37c9"
-    },
-    "m_Name": "AOMap",
-    "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "AOMap",
-    "m_DefaultReferenceName": "_AOMap",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_UseCustomSlotLabel": false,
-    "m_CustomSlotLabel": "",
-    "m_DismissedVersion": 0,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "813000c1ec3b409eb564a245f42e890f",
+    "m_Id": 0,
+    "m_DisplayName": "SpecularColor",
+    "m_SlotType": 1,
     "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
     "m_Value": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
-        "m_Guid": ""
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
-    "isMainTexture": false,
-    "useTilingAndOffset": false,
-    "m_Modifiable": true,
-    "m_DefaultType": 0
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
 }
 
 {
@@ -3149,37 +2856,25 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "8a353c6ffe9344438d756d6d5d6f7306",
-    "m_Group": {
-        "m_Id": "161e8762977a421496347a75ca55bbf6"
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "8a2e88af140e4b59b87ea06926e001c2",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -652.0,
-            "y": 695.0,
-            "width": 123.00006103515625,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "c6b8119d98fd40da90433854063e6fab"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "826e9a9595f145ae8f8dbf4644429123"
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -3196,54 +2891,6 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
-    "m_ObjectId": "8aae8bfaa7ce49a49a464b4e04e3a899",
-    "m_Id": 2,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "e00": 0.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 0.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 0.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 0.0
-    },
-    "m_DefaultValue": {
-        "e00": 1.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 1.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 1.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 1.0
-    }
 }
 
 {
@@ -3320,30 +2967,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
-    "m_ObjectId": "8ef8e770565b4b02aba61695a6b19cdd",
-    "m_Id": 0,
-    "m_DisplayName": "Normal (Tangent Space)",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "NormalTS",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_Space": 3
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.FloorNode",
     "m_ObjectId": "8f392067f4c84936b08a28acb91f9047",
     "m_Group": {
@@ -3354,10 +2977,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -782.0,
-            "y": 442.0,
+            "x": -780.0000610351563,
+            "y": 419.0000305175781,
             "width": 128.00006103515626,
-            "height": 94.0
+            "height": 93.99996948242188
         }
     },
     "m_Slots": [
@@ -3392,10 +3015,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1250.0001220703125,
-            "y": 652.0,
-            "width": 139.0,
-            "height": 118.0
+            "x": -1107.0,
+            "y": -221.0,
+            "width": 138.99993896484376,
+            "height": 118.00000762939453
         }
     },
     "m_Slots": [
@@ -3526,7 +3149,7 @@
     "m_ObjectId": "97321bc38ddc47a89116a2030907553e",
     "m_Datas": [],
     "m_ActiveSubTarget": {
-        "m_Id": "aa39f25130e44d7cb79ec980d308debb"
+        "m_Id": "51c1eb23a4004cceb631d2c85a28df50"
     },
     "m_AllowMaterialOverride": false,
     "m_SurfaceType": 0,
@@ -3592,57 +3215,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.NormalVectorNode",
-    "m_ObjectId": "9b724728ee0a419792d875c4fc2b433a",
-    "m_Group": {
-        "m_Id": "2cb95ef2ae034f419ace077f95de0bd1"
-    },
-    "m_Name": "Normal Vector",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -1691.0001220703125,
-            "y": 1058.0001220703125,
-            "width": 206.0,
-            "height": 130.9998779296875
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "f52c7d760e624fbc826e6da2d4d08548"
-        }
-    ],
-    "synonyms": [
-        "surface direction"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 2,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Space": 3
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "9c6009f4fd4d446396a90b2f244a33ad",
-    "m_Id": 4,
-    "m_DisplayName": "R",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "R",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "9c66fac5338f4ac1803ffe6c6517b3c9",
     "m_Id": -597421976,
@@ -3662,40 +3234,6 @@
         "z": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "9ec1f14e37cb42ff9dec92d21b71f07f",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Emission",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "b024974f976042bb936560b31a674009"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Emission"
 }
 
 {
@@ -3765,6 +3303,30 @@
 }
 
 {
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "a2e9f586e9634d97bc944529a465dd9b",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
     "m_ObjectId": "a64d5d6c997547d79dcd7da03c4b9232",
@@ -3825,64 +3387,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
-    "m_ObjectId": "a78f5e98db5c4954a0ec3205ccbc5c5f",
-    "m_Id": 0,
-    "m_DisplayName": "A",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "e00": 0.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 0.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 0.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 0.0
-    },
-    "m_DefaultValue": {
-        "e00": 1.0,
-        "e01": 0.0,
-        "e02": 0.0,
-        "e03": 0.0,
-        "e10": 0.0,
-        "e11": 1.0,
-        "e12": 0.0,
-        "e13": 0.0,
-        "e20": 0.0,
-        "e21": 0.0,
-        "e22": 1.0,
-        "e23": 0.0,
-        "e30": 0.0,
-        "e31": 0.0,
-        "e32": 0.0,
-        "e33": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 2,
-    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
-    "m_ObjectId": "aa39f25130e44d7cb79ec980d308debb",
-    "m_WorkflowMode": 1,
-    "m_NormalDropOffSpace": 0,
-    "m_ClearCoat": false,
-    "m_BlendModePreserveSpecular": true
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SubGraphNode",
     "m_ObjectId": "abe7fd38155442778514408a281d905e",
     "m_Group": {
@@ -3938,6 +3442,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "abf799f907dd423ea40d4cfe10a3f978",
+    "m_Id": 186768313,
+    "m_DisplayName": "ShadowColor",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_ShadowColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.6000000238418579,
+        "y": 0.6000000238418579,
+        "z": 0.6000000238418579,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "abff77923ab34daebe72d8b1c4188a93",
     "m_Id": -339869344,
@@ -3955,40 +3484,10 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.GroupData",
     "m_ObjectId": "ac5bd7ac8c3e453d8bf386077e640532",
-    "m_Title": "Emission",
+    "m_Title": "Fresnel Controls",
     "m_Position": {
-        "x": -1118.0001220703125,
-        "y": -108.99999237060547
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
-    "m_ObjectId": "b024974f976042bb936560b31a674009",
-    "m_Id": 0,
-    "m_DisplayName": "Emission",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Emission",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": [],
-    "m_ColorMode": 1,
-    "m_DefaultColor": {
-        "r": 0.0,
-        "g": 0.0,
-        "b": 0.0,
-        "a": 1.0
+        "x": -1115.7000732421875,
+        "y": 207.9999542236328
     }
 }
 
@@ -4005,6 +3504,24 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "b47c87c2da3344eda6f8e3ce0cd30d59",
+    "m_Id": 558820014,
+    "m_DisplayName": "PainterlyTexture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_PainterlyTexture",
+    "m_StageCapability": 2,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"fileID\":2800000,\"guid\":\"918130781bc469c44b95dffa9abfa325\",\"type\":3}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
 }
 
 {
@@ -4072,70 +3589,17 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "b74dcc58a76448b69c275326e87f4ec2",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Occlusion",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "0e7913707b264f65bffbd639243aea51"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
-    "m_ObjectId": "b82b033dbd5d4e3e963dbefd2a022528",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "SurfaceDescription.Smoothness",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 0.0,
-            "height": 0.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "e603fd73b68f4629aef322cb69319a2c"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "b82abf752eb04b20b40673411e2ae74d",
+    "m_Id": 1269135353,
+    "m_DisplayName": "SpecularCutoff",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_SpecularCutoff",
+    "m_StageCapability": 2,
+    "m_Value": 0.6000000238418579,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -4188,27 +3652,55 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "bbc92a58ac1344e4b63eb311b5dff878",
-    "m_Id": 0,
-    "m_DisplayName": "BaseColor",
-    "m_SlotType": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
+    "m_ObjectId": "bf2ef47f1c64413e9ec45bd5ba25c84f",
+    "m_Id": 164958765,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
+    "m_ShaderOutputName": "_Normal",
+    "m_StageCapability": 2,
     "m_Value": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
         "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
+        "z": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "bf97d9783173481598953b288718a59a",
+    "m_Guid": {
+        "m_GuidSerialized": "48d00123-2051-461d-ab9c-102db999c688"
+    },
+    "m_Name": "SpecularColor",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "SpecularColor",
+    "m_DefaultReferenceName": "_SpecularColor",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 0.0
+    },
+    "isMainColor": false,
+    "m_ColorMode": 0
 }
 
 {
@@ -4228,19 +3720,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
-    "m_ObjectId": "c6b8119d98fd40da90433854063e6fab",
-    "m_Id": 0,
-    "m_DisplayName": "AOMap",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_BareResource": false
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "c7fd784a897a4fbcaa7a5480c0b0b6ad",
     "m_Group": {
@@ -4251,10 +3730,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -873.0,
-            "y": -53.99998092651367,
-            "width": 144.0001220703125,
-            "height": 34.00004196166992
+            "x": -879.0000610351563,
+            "y": -219.00001525878907,
+            "width": 144.0,
+            "height": 33.999969482421878
         }
     },
     "m_Slots": [
@@ -4272,30 +3751,6 @@
     },
     "m_Property": {
         "m_Id": "5247f3bc5c8f4f3c9e226f18f686db0d"
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "c977c6d9a7594b3db2adca53668e70e6",
-    "m_Id": 0,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
     }
 }
 
@@ -4339,10 +3794,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1093.0,
-            "y": 442.0,
-            "width": 147.00006103515626,
-            "height": 34.0
+            "x": -1091.0,
+            "y": 419.0000305175781,
+            "width": 146.99993896484376,
+            "height": 33.999969482421878
         }
     },
     "m_Slots": [
@@ -4469,6 +3924,31 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "d12dd8a84df14bed98a950fdfa3dc761",
+    "m_Id": 1841062939,
+    "m_DisplayName": "DiffuseColor",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "_DiffuseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.800000011920929,
+        "y": 0.800000011920929,
+        "z": 0.800000011920929,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "d1b856950eb241d7b1c5db10e264bc99",
     "m_Group": {
@@ -4479,10 +3959,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1812.0001220703125,
-            "y": 841.0000610351563,
+            "x": -1459.0,
+            "y": -186.9999542236328,
             "width": 144.0,
-            "height": 34.0
+            "height": 33.99998474121094
         }
     },
     "m_Slots": [
@@ -4500,6 +3980,42 @@
     },
     "m_Property": {
         "m_Id": "1b5bb67bb55a4bbda282f79c276dbb56"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "d49f265460374f5dbde10f63ddd67271",
+    "m_Group": {
+        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -863.0,
+            "y": 22.0,
+            "width": 147.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "6d09f8f669af4fc0b47b3cff48b810c7"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "5c952bddea134e47aef18992c2bf4847"
     }
 }
 
@@ -4569,15 +4085,63 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
-    "m_ObjectId": "d88a06f4f74649a7b90b16ff61387879",
-    "m_Id": 3,
-    "m_DisplayName": "Sampler",
-    "m_SlotType": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "da82c36db55b4fb8872ea26a1d8fdde8",
+    "m_Id": 0,
+    "m_DisplayName": "DiffuseColor",
+    "m_SlotType": 1,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Sampler",
+    "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
-    "m_BareResource": false
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "db93a193d2364837bd8ce004ed486f9d",
+    "m_Group": {
+        "m_Id": "30728c35ddbe42ec95150e3ffcac58bd"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -867.0,
+            "y": -46.0,
+            "width": 151.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "813000c1ec3b409eb564a245f42e890f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "bf97d9783173481598953b288718a59a"
+    }
 }
 
 {
@@ -4659,48 +4223,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.KeywordNode",
-    "m_ObjectId": "ded39eb2ba814bdcae1e8c2db652b67a",
-    "m_Group": {
-        "m_Id": "2cb95ef2ae034f419ace077f95de0bd1"
-    },
-    "m_Name": "UseNormalMap",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -1411.0001220703125,
-            "y": 964.0000610351563,
-            "width": 139.0,
-            "height": 117.99993896484375
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "c977c6d9a7594b3db2adca53668e70e6"
-        },
-        {
-            "m_Id": "259cf6afeae44aab9bfcaec6f1e206c7"
-        },
-        {
-            "m_Id": "1558cd30c99d4127be92b324cac00d6f"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": false,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Keyword": {
-        "m_Id": "a64d5d6c997547d79dcd7da03c4b9232"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "df1174a794a24184b63f4372db0cd4e5",
     "m_Group": {
@@ -4711,10 +4233,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -476.0,
-            "y": 299.0,
-            "width": 130.0,
-            "height": 118.0
+            "x": -474.0000915527344,
+            "y": 276.0000305175781,
+            "width": 208.00009155273438,
+            "height": 302.0000305175781
         }
     },
     "m_Slots": [
@@ -4747,6 +4269,30 @@
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "e00a72d034c5487dbd7203520e61214b",
     "m_Id": 0,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "e1a3d6005e4549898304d75cc2efbdb9",
+    "m_Id": 1,
     "m_DisplayName": "Out",
     "m_SlotType": 1,
     "m_Hidden": false,
@@ -4807,21 +4353,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "e603fd73b68f4629aef322cb69319a2c",
-    "m_Id": 0,
-    "m_DisplayName": "Smoothness",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Smoothness",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.5,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
     "m_ObjectId": "e8f31b54af48432894660c6e4e97eeca",
     "m_Id": 1,
@@ -4845,10 +4376,10 @@
     "m_Guid": {
         "m_GuidSerialized": "8b7f64b9-ccbc-4dd3-8003-5377a13e9314"
     },
-    "m_Name": "BaseColor",
+    "m_Name": "DiffuseColor",
     "m_DefaultRefNameVersion": 1,
-    "m_RefNameGeneratedByDisplayName": "BaseColor",
-    "m_DefaultReferenceName": "_BaseColor",
+    "m_RefNameGeneratedByDisplayName": "DiffuseColor",
+    "m_DefaultReferenceName": "_DiffuseColor",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
     "m_UseCustomSlotLabel": false,
@@ -4859,9 +4390,9 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "r": 1.0,
-        "g": 1.0,
-        "b": 1.0,
+        "r": 0.800000011920929,
+        "g": 0.800000011920929,
+        "b": 0.800000011920929,
         "a": 0.0
     },
     "isMainColor": false,
@@ -4952,31 +4483,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
-    "m_ObjectId": "eb782c5f81b449d29783549f95172d7a",
-    "m_Id": 0,
-    "m_DisplayName": "RGBA",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "RGBA",
-    "m_StageCapability": 2,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
     "m_ObjectId": "ebcffba17f08413c8fb0474e09ee2ec6",
     "m_Id": 2,
@@ -4995,29 +4501,6 @@
     },
     "m_Labels": [],
     "m_Channel": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "ebed97b71d18469a8ce46fca4fed7713",
-    "m_Id": 1,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
 }
 
 {
@@ -5161,10 +4644,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -1478.0001220703125,
-            "y": 676.0,
+            "x": -1338.0,
+            "y": 30.0,
             "width": 206.0,
-            "height": 131.00006103515626
+            "height": 130.99996948242188
         }
     },
     "m_Slots": [
@@ -5182,22 +4665,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     },
-    "m_Space": 2
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "f36af3c572574959a133a2cec54c406a",
-    "m_Id": 0,
-    "m_DisplayName": "Metallic",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Metallic",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
+    "m_Space": 0
 }
 
 {
@@ -5212,10 +4680,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -693.0,
-            "y": 166.0,
+            "x": -800.0000610351563,
+            "y": 121.00000762939453,
             "width": 147.0,
-            "height": 34.0
+            "height": 33.999977111816409
         }
     },
     "m_Slots": [
@@ -5239,57 +4707,16 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "f484082f4a434d67ae8cd2513c8f91a6",
-    "m_Id": 7,
-    "m_DisplayName": "A",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "A",
-    "m_StageCapability": 2,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
-    "m_ObjectId": "f52c7d760e624fbc826e6da2d4d08548",
-    "m_Id": 0,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0
-    },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
-    "m_ObjectId": "fbb5378cbc234d17b565ac1770a5274b",
-    "m_Id": 1,
-    "m_DisplayName": "Texture",
+    "m_ObjectId": "f9daa7f963ef414abd7fd35dfc0e522f",
+    "m_Id": -1238829770,
+    "m_DisplayName": "ShadowCutoff",
     "m_SlotType": 0,
     "m_Hidden": false,
-    "m_ShaderOutputName": "Texture",
-    "m_StageCapability": 3,
-    "m_BareResource": false,
-    "m_Texture": {
-        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
-        "m_Guid": ""
-    },
-    "m_DefaultType": 0
+    "m_ShaderOutputName": "_ShadowCutoff",
+    "m_StageCapability": 2,
+    "m_Value": 0.4000000059604645,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -5304,10 +4731,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -533.0,
-            "y": -2.9999704360961916,
-            "width": 145.00015258789063,
-            "height": 118.00005340576172
+            "x": -653.0000610351563,
+            "y": 53.999977111816409,
+            "width": 145.00006103515626,
+            "height": 117.99999237060547
         }
     },
     "m_Slots": [


### PR DESCRIPTION
Shader is now unlit and uses the painterly subgraph to achieve stylized lighting beneath the fresnel effect. There's no controls for the cutoff values and painterly texture, but that can be added later if needed.